### PR TITLE
project 3: Anonymous page 구현

### DIFF
--- a/include/lib/debug.h
+++ b/include/lib/debug.h
@@ -16,6 +16,7 @@
 void debug_panic (const char *file, int line, const char *function,
 		const char *message, ...) PRINTF_FORMAT (4, 5) NO_RETURN;
 void debug_backtrace (void);
+#define VM
 
 #endif
 

--- a/include/vm/file.h
+++ b/include/vm/file.h
@@ -1,7 +1,7 @@
 #ifndef VM_FILE_H
 #define VM_FILE_H
 #include "filesys/file.h"
-#include "vm/vm.h"
+// #include "vm/vm.h"
 
 struct page;
 enum vm_type;

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -2,6 +2,7 @@
 #define VM_VM_H
 #include <stdbool.h>
 #include "threads/palloc.h"
+#include "kernel/hash.h"
 
 enum vm_type {
 	/* page not initialized */
@@ -46,6 +47,8 @@ struct page {
 	struct frame *frame;   /* Back reference for frame */
 
 	/* Your implementation */
+	struct hash_elem hash_elem;
+	bool writable;
 
 	/* Per-type data are binded into the union.
 	 * Each function automatically detects the current union */
@@ -57,6 +60,17 @@ struct page {
 		struct page_cache page_cache;
 #endif
 	};
+};
+
+/* load_segment()에서 파일을 lazy load할 때 쓰는 구조체
+ */
+struct load_field {
+	struct file *file;
+	off_t ofs;
+	uint32_t zero_bytes;
+	uint32_t read_bytes;
+	uint8_t *upage;
+	bool writable;
 };
 
 /* The representation of "frame" */
@@ -85,6 +99,7 @@ struct page_operations {
  * We don't want to force you to obey any specific design for this struct.
  * All designs up to you for this. */
 struct supplemental_page_table {
+	struct hash spt_hash;
 };
 
 #include "threads/thread.h"
@@ -108,5 +123,7 @@ bool vm_alloc_page_with_initializer (enum vm_type type, void *upage,
 void vm_dealloc_page (struct page *page);
 bool vm_claim_page (void *va);
 enum vm_type page_get_type (struct page *page);
+
+void init_load_field(struct load_field* load_field, struct file* file, off_t ofs, size_t zero_bytes, size_t read_bytes, bool writable);
 
 #endif  /* VM_VM_H */

--- a/lib/kernel/hash.c
+++ b/lib/kernel/hash.c
@@ -8,6 +8,7 @@
 #include "hash.h"
 #include "../debug.h"
 #include "threads/malloc.h"
+#include "include/vm/file.h"
 
 #define list_elem_to_hash_elem(LIST_ELEM)                       \
 	list_entry(LIST_ELEM, struct hash_elem, list_elem)
@@ -83,6 +84,7 @@ hash_destroy (struct hash *h, hash_action_func *destructor) {
 		hash_clear (h, destructor);
 	free (h->buckets);
 }
+
 
 /* Inserts NEW into hash table H and returns a null pointer, if
    no equal element is already in the table.

--- a/threads/mmu.c
+++ b/threads/mmu.c
@@ -94,7 +94,7 @@ pml4e_walk (uint64_t *pml4e, const uint64_t va, int create) {
  * allocation fails. */
 uint64_t *
 pml4_create (void) {
-	uint64_t *pml4 = palloc_get_page (0);
+	uint64_t *pml4 = palloc_get_page (0); //플래그로 0을 넘김 -> 플래그 없이 기본 설정값으로 할당을 요청하겠다는 의미. 이 경우 커널 풀에 할당됨
 	if (pml4)
 		memcpy (pml4, base_pml4, PGSIZE);
 	return pml4;

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -261,6 +261,8 @@ tid_t thread_create(const char *name, int priority, thread_func *function,
     t->stdout_count = 1;
     tid = t->tid = allocate_tid();
 
+    supplemental_page_table_init(&t->spt);
+
     struct thread *cur = thread_current();
     list_push_back(&cur->child_list, &t->child_elem);
 

--- a/userprog/exception.c
+++ b/userprog/exception.c
@@ -140,7 +140,9 @@ static void page_fault(struct intr_frame *f) {
     if (vm_try_handle_fault(f, fault_addr, user, write, not_present))
         return;
 #endif
-    exit(-1);
+   if(!is_user_vaddr(fault_addr) || pml4_get_page(thread_current()->pml4, fault_addr) == NULL || fault_addr == NULL){
+      exit(-1);
+   }
 
     /* Count page faults. */
     page_fault_cnt++;

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -122,8 +122,8 @@ void syscall_handler(struct intr_frame *f UNUSED) {
 /* ---------------validator---------------- */
 
 bool validate_user_address(void *address) {
-    if (!is_user_vaddr(address) ||
-        pml4_get_page(thread_current()->pml4, address) == NULL) {
+    if (!is_user_vaddr(address)
+        || pml4_get_page(thread_current()->pml4, address) == NULL){
         return false;
     }
     return true;

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -3,6 +3,15 @@
 #include "threads/malloc.h"
 #include "vm/vm.h"
 #include "vm/inspect.h"
+#include "threads/vaddr.h"
+#include "threads/mmu.h"
+
+/* page의 va를 해싱하는 함수 */
+uint64_t page_hash (const struct hash_elem *e, void *aux);
+
+/* va 기준으로 순서 비교 */
+bool page_less (const struct hash_elem *a, const struct hash_elem *b, void *aux UNUSED);
+
 
 /* Initializes the virtual memory subsystem by invoking each subsystem's
  * intialize codes. */
@@ -17,6 +26,15 @@ vm_init (void) {
 	/* DO NOT MODIFY UPPER LINES. */
 	/* TODO: Your code goes here. */
 }
+
+// void init_load_field(struct load_field* load_field, struct file* file, off_t ofs, uint8_t* upage, uint32_t read_bytes, uint32_t zero_bytes, bool writable){
+// 	load_field->file = file;
+// 	load_field->ofs = ofs;
+// 	load_field->upage = upage;
+// 	load_field->read_bytes = read_bytes;
+// 	load_field->zero_bytes = zero_bytes;
+// 	load_field->writable = writable;
+// }
 
 /* Get the type of the page. This function is useful if you want to know the
  * type of the page after it will be initialized.
@@ -47,6 +65,7 @@ vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
 	ASSERT (VM_TYPE(type) != VM_UNINIT)
 
 	struct supplemental_page_table *spt = &thread_current ()->spt;
+	struct page* p;
 
 	/* Check wheter the upage is already occupied or not. */
 	if (spt_find_page (spt, upage) == NULL) {
@@ -54,33 +73,98 @@ vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
 		 * TODO: and then create "uninit" page struct by calling uninit_new. You
 		 * TODO: should modify the field after calling the uninit_new. */
 
-		/* TODO: Insert the page into the spt. */
+		// 페이지를 하나 만들어주고 vm type에 맞는 initializer를 인자로 갖는 uninit_new함수를 호출한다.
+		// palloc_get_page()는 1page(4KB)를, malloc(sizeof(struct page))는 page구조체 만큼의 공간을 할당해준다는 차이만 있을 뿐.. 두개 중 뭘 쓰든 상관 없나? 페이지 구조체를 생성하고자하는 상황이므로 malloc이 더 적합하다고 판단되어 malloc 사용함
+
+		// struct page* p = palloc_get_page(PAL_USER);
+		
+		p = (struct page*)malloc(sizeof(struct page));
+		if(p == NULL) 
+			return false;
 	}
+
+	bool(*page_initializer)(struct page*, enum vm_type, void *kva);
+		
+		switch(VM_TYPE(type)){
+			case VM_ANON:
+			// uninit_new(p, p->va, init, type, NULL, anon_initializer);
+			// uninit_new(p, upage, init, type, aux, anon_initializer);
+			page_initializer = anon_initializer;
+			
+			break;
+			case VM_FILE:
+			// uninit_new(p, p->va, init, type, NULL, file_backed_initializer);
+			// uninit_new(p, upage, init, type, aux, file_backed_initializer);	
+			page_initializer = file_backed_initializer;
+			break;			
+		}	
+
+		uninit_new(p, upage, init, type, aux, page_initializer);
+
+		p->writable = writable;
+
+		/* TODO: Insert the page into the spt. */
+		int result = spt_insert_page(spt, p);
+		// printf("result: %d", result);
+		return result;
+		// return true;
 err:
 	return false;
 }
 
 /* Find VA from spt and return page. On error, return NULL. */
+//spt가 va에 해당하는 page를 가지고 있는지 찾아서 리턴, 못 찾으면 NULL 리턴
 struct page *
 spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
-	struct page *page = NULL;
+	struct page p;
+	struct hash_elem *e;
+	
 	/* TODO: Fill this function. */
+	//hash table 탐색 : dummy.hash_elem주소를 넣으면 해시 테이블 내부에서 같은 va를 가진 요소를 찾아줌
+	p.va = pg_round_down(va); //검색할 키를 정렬된 값으로 세팅
+	e = hash_find(&spt->spt_hash, &p.hash_elem); //해시 테이블, 검색용 포인터를 넘김
 
-	return page;
+	// 지워도 되는 부분
+	// struct hash_iterator *i;
+	// hash_first(i, &spt->spt_hash);
+	// struct hash_elem *elem = hash_cur(i);
+	// struct page *page = hash_entry(elem, struct page, hash_elem);
+	// printf("elem = %p", elem);
+	// printf("page elem = %p",page->hash_elem);
+
+	// 지워도 되는 부분
+
+	if(e == NULL){
+		// printf("nulllllllll");
+		return NULL;
+	}
+
+	//hash_elem 포인터 -> struct page 포인터로 변환
+	return hash_entry(e, struct page, hash_elem);	
 }
 
 /* Insert PAGE into spt with validation. */
 bool
 spt_insert_page (struct supplemental_page_table *spt UNUSED,
 		struct page *page UNUSED) {
-	int succ = false;
-	/* TODO: Fill this function. */
+	bool succ = false;
 
+	/* TODO: Fill this function. */
+	//va에 대응하는 struct page의 hash_elem을 spt의 hash table에 등록
+	if(spt_find_page(spt, page->va) == NULL){
+		hash_insert(&spt->spt_hash, &page->hash_elem);
+		succ = true;
+	}
 	return succ;
 }
 
 void
 spt_remove_page (struct supplemental_page_table *spt, struct page *page) {
+	struct hash_elem *e = hash_find(&spt->spt_hash, &page->hash_elem);
+	if(e == NULL){
+		return false;
+	}
+	hash_delete(&spt->spt_hash, e);
 	vm_dealloc_page (page);
 	return true;
 }
@@ -110,8 +194,31 @@ vm_evict_frame (void) {
  * space.*/
 static struct frame *
 vm_get_frame (void) {
-	struct frame *frame = NULL;
 	/* TODO: Fill this function. */
+	/*
+	유저 메모리 풀에서 palloc_get_page()로 새로운 물리 프레임 할당받기
+	1. free 프레임인지 확인해야 함
+	2. free 프레임이 없다면 특정 프레임을 디스크로 쫓아내 free로 만들어주고 그 프레임을 가져와야 함
+		디스크로 쫓아낼 프레임을 고르는 방법은 페이지 테이블의 accessed, dirty 비트를 참조하는 것이다.
+		프레임을 쫓아냈다면 그 프레임을 참조하는 모든 페이지 테이블에서 참조를 제거한다. 공유되지 않았다면 해당 프레임을 참조하는 페이지는 항상 한 개만 존재해야 한다.
+		필요하다면 쫓아낸 페이지를 파일 시스템이나 스왑에 write해야 함
+	3. 스왑 영역 마저 꽉 차있다면 커널 패닉을 발생시킴 <-???
+	*/
+	//free된 frame인지 구현해야됨
+	
+	/* 프레임 정보를 담을 공간 할당 */
+	struct frame* frame = (struct frame*)malloc(sizeof(struct frame));
+	
+	/* 물리 메모리에 프레임 할당 */
+	// void* kva = palloc_get_page(PAL_USER);
+	uint64_t *kva = palloc_get_multiple(PAL_USER, 1);
+	if(kva == NULL){
+		PANIC("No memory.");
+	}
+
+	/* frame과 va를 매핑 */
+	frame->kva = kva;
+	frame->page = NULL;
 
 	ASSERT (frame != NULL);
 	ASSERT (frame->page == NULL);
@@ -132,11 +239,41 @@ vm_handle_wp (struct page *page UNUSED) {
 bool
 vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
 		bool user UNUSED, bool write UNUSED, bool not_present UNUSED) {
+
 	struct supplemental_page_table *spt UNUSED = &thread_current ()->spt;
-	struct page *page = NULL;
+
+
 	/* TODO: Validate the fault */
 	/* TODO: Your code goes here */
 
+	/*
+	1. 접근한 주소가 유효한지 확인 (done)
+			주소가 NULL이거나 KERN_BASE보다 크면 유저 프로그램이 접근할 수 없는 영역이므로 false 리턴
+	2. spt에서 해당 가상 주소에 해당하는 page 구조체가 있는지 확인 (done)
+			현재 spt에서 addr에 해당하는 page가 있는지 찾기
+			아직 없다면 lazy load되지 않은 영역이거나 stack 확장이 필요할 수 있다
+	3. stack growth 가능성 확인 
+			접근한 주소가 스택 포인터 근처이고, 사용자 영역 내에 있다면 스택 확장 허용
+			vm_stack_growth()함수로 새 page를 spt에 등록하고 다시 찾음
+	4. 정상적인 page를 찾았으면 claim 요청
+			page가 spt에 존재하고 접근도 유효하다가 판단되었으므로 해당 page를 메모리에 올리기 위한 claim작업 진행 (frame 할당 + 파일/anon페이지 내용 로딩)
+	*/
+
+	// if(addr == NULL || addr > KERN_BASE)
+	// 	return false;
+	
+	//페이지를 찾고
+	// struct page* page = spt_find_page(&spt->spt_hash, &addr);
+	struct page* page = spt_find_page(spt, addr);
+
+	if(page == NULL){ //아직 페이지가 없으면 유효하지 않은 접근
+		//todo: 스택의 경우 페이지를 만들어준다
+		// if(스택을 자동으로 확장시켜줘야 하는 경우){
+			// return vm_alloc_page_with_initializer(VM_ANON, addr, 1, anon_initializer, NULL);
+		// }
+		// printf("NULL!!!!!!!!!");
+		return false;
+	} 
 	return vm_do_claim_page (page);
 }
 
@@ -151,9 +288,11 @@ vm_dealloc_page (struct page *page) {
 /* Claim the page that allocate on VA. */
 bool
 vm_claim_page (void *va UNUSED) {
-	struct page *page = NULL;
+	struct page *page;
 	/* TODO: Fill this function */
-
+	page = spt_find_page(&thread_current()->spt, va);
+	if(page == NULL) return false;
+	// if(page->frame != NULL) return true;
 	return vm_do_claim_page (page);
 }
 
@@ -167,6 +306,17 @@ vm_do_claim_page (struct page *page) {
 	page->frame = frame;
 
 	/* TODO: Insert page table entry to map page's VA to frame's PA. */
+	/*
+	인자로 주어진 page에 물리 프레임을 할당
+	1. vm_get_frame()을 호출하여 프레임 하나를 할당받기
+	2. mmu 세팅하기
+		va-pa 매핑 정보를 page table에 추가하기: threads/mmu.c에 있는 함수 사용하기
+	3. 1, 2번 연산이 성공했으면 true 반환, 그렇지 않으면 false 반환
+	*/
+
+	if(!pml4_set_page(thread_current()->pml4, page->va, frame->kva, page->writable)){
+		return false;
+	}
 
 	return swap_in (page, frame->kva);
 }
@@ -174,17 +324,43 @@ vm_do_claim_page (struct page *page) {
 /* Initialize new supplemental page table */
 void
 supplemental_page_table_init (struct supplemental_page_table *spt UNUSED) {
+	hash_init(&spt->spt_hash, page_hash, page_less, NULL);
 }
 
+uint64_t page_hash (const struct hash_elem *e, void *aux){
+	const struct page* p = hash_entry(e, struct page, hash_elem);
+	return hash_bytes(&p->va, sizeof(p->va));
+}
+
+bool page_less (const struct hash_elem *a,
+           const struct hash_elem *b,
+           void *aux UNUSED) {
+    const struct page *p_a = hash_entry (a, struct page, hash_elem);
+    const struct page *p_b = hash_entry (b, struct page, hash_elem);
+    return p_a->va < p_b->va;
+}
+ 
 /* Copy supplemental page table from src to dst */
 bool
 supplemental_page_table_copy (struct supplemental_page_table *dst UNUSED,
 		struct supplemental_page_table *src UNUSED) {
+	
 }
 
+void hash_destructor (struct hash_elem *e, void *aux){
+	//hash_elem이 포함된 페이지를 free시키기
+	struct page* p = hash_entry(e, struct page, hash_elem);
+	//page free 시키기
+	// free(p);
+	// hash_delete(&thread_current()->spt, e);
+	spt_remove_page(&thread_current()->spt, p);
+	
+}
 /* Free the resource hold by the supplemental page table */
 void
 supplemental_page_table_kill (struct supplemental_page_table *spt UNUSED) {
 	/* TODO: Destroy all the supplemental_page_table hold by thread and
 	 * TODO: writeback all the modified contents to the storage. */
+	hash_clear(spt, hash_destructor);
 }
+


### PR DESCRIPTION
supplemental_page_table_copy()
supplemental_page_table_kill()
구현 중입니당

pass tests/userprog/args-none
pass tests/userprog/args-single
pass tests/userprog/args-multiple
pass tests/userprog/args-many
pass tests/userprog/args-dbl-space
pass tests/userprog/halt
pass tests/userprog/exit
pass tests/userprog/create-normal
pass tests/userprog/create-empty
pass tests/userprog/create-null
pass tests/userprog/create-bad-ptr
pass tests/userprog/create-long
pass tests/userprog/create-exists
pass tests/userprog/create-bound
pass tests/userprog/open-normal
pass tests/userprog/open-missing
pass tests/userprog/open-boundary
pass tests/userprog/open-empty
pass tests/userprog/open-null
pass tests/userprog/open-bad-ptr
pass tests/userprog/open-twice
pass tests/userprog/close-normal
pass tests/userprog/close-twice
pass tests/userprog/close-bad-fd
pass tests/userprog/read-normal
pass tests/userprog/read-bad-ptr
FAIL tests/userprog/read-boundary
pass tests/userprog/read-zero
pass tests/userprog/read-stdout
pass tests/userprog/read-bad-fd
pass tests/userprog/write-normal
pass tests/userprog/write-bad-ptr
pass tests/userprog/write-boundary
pass tests/userprog/write-zero
pass tests/userprog/write-stdin
pass tests/userprog/write-bad-fd
FAIL tests/userprog/fork-once
FAIL tests/userprog/fork-multiple
FAIL tests/userprog/fork-recursive
FAIL tests/userprog/fork-read
FAIL tests/userprog/fork-close
FAIL tests/userprog/fork-boundary
pass tests/userprog/exec-once
pass tests/userprog/exec-arg
FAIL tests/userprog/exec-boundary
pass tests/userprog/exec-missing
pass tests/userprog/exec-bad-ptr
FAIL tests/userprog/exec-read
FAIL tests/userprog/wait-simple
FAIL tests/userprog/wait-twice
FAIL tests/userprog/wait-killed
pass tests/userprog/wait-bad-pid
FAIL tests/userprog/multi-recurse
FAIL tests/userprog/multi-child-fd
pass tests/userprog/rox-simple
FAIL tests/userprog/rox-child
FAIL tests/userprog/rox-multichild
pass tests/userprog/bad-read
pass tests/userprog/bad-write
pass tests/userprog/bad-read2
pass tests/userprog/bad-write2
pass tests/userprog/bad-jump
pass tests/userprog/bad-jump2
FAIL tests/vm/pt-grow-stack
pass tests/vm/pt-grow-bad
FAIL tests/vm/pt-big-stk-obj
pass tests/vm/pt-bad-addr
pass tests/vm/pt-bad-read
pass tests/vm/pt-write-code
FAIL tests/vm/pt-write-code2
FAIL tests/vm/pt-grow-stk-sc
pass tests/vm/page-linear
FAIL tests/vm/page-parallel
FAIL tests/vm/page-merge-seq
FAIL tests/vm/page-merge-par
FAIL tests/vm/page-merge-stk
FAIL tests/vm/page-merge-mm
pass tests/vm/page-shuffle
FAIL tests/vm/mmap-read
FAIL tests/vm/mmap-close
FAIL tests/vm/mmap-unmap
FAIL tests/vm/mmap-overlap
FAIL tests/vm/mmap-twice
FAIL tests/vm/mmap-write
FAIL tests/vm/mmap-ro
FAIL tests/vm/mmap-exit
FAIL tests/vm/mmap-shuffle
FAIL tests/vm/mmap-bad-fd
FAIL tests/vm/mmap-clean
FAIL tests/vm/mmap-inherit
FAIL tests/vm/mmap-misalign
FAIL tests/vm/mmap-null
FAIL tests/vm/mmap-over-code
FAIL tests/vm/mmap-over-data
FAIL tests/vm/mmap-over-stk
FAIL tests/vm/mmap-remove
FAIL tests/vm/mmap-zero
FAIL tests/vm/mmap-bad-fd2
FAIL tests/vm/mmap-bad-fd3
FAIL tests/vm/mmap-zero-len
FAIL tests/vm/mmap-off
FAIL tests/vm/mmap-bad-off
FAIL tests/vm/mmap-kernel
FAIL tests/vm/lazy-file
pass tests/vm/lazy-anon
FAIL tests/vm/swap-file
FAIL tests/vm/swap-anon
FAIL tests/vm/swap-iter
FAIL tests/vm/swap-fork
pass tests/filesys/base/lg-create
pass tests/filesys/base/lg-full
pass tests/filesys/base/lg-random
pass tests/filesys/base/lg-seq-block
pass tests/filesys/base/lg-seq-random
pass tests/filesys/base/sm-create
pass tests/filesys/base/sm-full
pass tests/filesys/base/sm-random
pass tests/filesys/base/sm-seq-block
pass tests/filesys/base/sm-seq-random
FAIL tests/filesys/base/syn-read
pass tests/filesys/base/syn-remove
FAIL tests/filesys/base/syn-write
pass tests/threads/alarm-single
pass tests/threads/alarm-multiple
pass tests/threads/alarm-simultaneous
pass tests/threads/alarm-priority
pass tests/threads/alarm-zero
pass tests/threads/alarm-negative
pass tests/threads/priority-change
pass tests/threads/priority-donate-one
pass tests/threads/priority-donate-multiple
pass tests/threads/priority-donate-multiple2
pass tests/threads/priority-donate-nest
pass tests/threads/priority-donate-sema
pass tests/threads/priority-donate-lower
pass tests/threads/priority-fifo
pass tests/threads/priority-preempt
pass tests/threads/priority-sema
pass tests/threads/priority-condvar
pass tests/threads/priority-donate-chain
FAIL tests/vm/cow/cow-simple
58 of 141 tests failed.